### PR TITLE
docs: add 2025 training materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [各面向工具](https://github.com/nics-tw/resilience-material/releases/download/2025/3_Digital_Resilience-Related_Tools.pdf)（SHA256: 319aa25a3c9ee91c03b6c8692e9a034f20e2439ebe4d6f379166b7128b89db79）
 - [高可用性構面](https://github.com/nics-tw/resilience-material/releases/download/2025/4_High-Availability.pdf)（SHA256: d1e3601897a9e63ff19ff0dfad8b4f93493aafd88283aa8c34cd5d7c62c88eed）
 - [可維護性構面](https://github.com/nics-tw/resilience-material/releases/download/2025/5_Maintainability.pdf)（SHA256: 21db868fd033ec6ec7a964c754ef9e9a24d741fa5ccba333b37565498df5edb5）
-- [實地輔導可維護性案例分享](https://github.com/nics-tw/resilience-material/releases/download/2025/6_Maintainability_Best_Practices.pdf)（SHA256: 4c116e03eb780fb763c689f28ae5fea87256da8467d4293f099166ef5bb07636）
+- [實地輔導可維護性案例分享](https://github.com/nics-tw/resilience-material/releases/download/2025/6_Maintainability_Case_Studies.pdf)（SHA256: 4c116e03eb780fb763c689f28ae5fea87256da8467d4293f099166ef5bb07636）
 - [實地輔導高可用性案例分享](https://github.com/nics-tw/resilience-material/releases/download/2025/7_High-Availability_Case_Studies.pdf)（SHA256: 4d768bc86ac37ba133bc4103ab72a132e928bd8ffdfb547a353d2dac47fa4bcd）
 
 ### [2024 年](https://github.com/nics-tw/resilience-material/releases/tag/2024)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@
 
 ## 數位韌性領航員培訓課程教材
 
+### [2025 年](https://github.com/nics-tw/resilience-material/releases/tag/2025)
+
+- [政府資訊系統數位韌性](https://github.com/nics-tw/resilience-material/releases/download/2025/1_Digital_Resilience.pdf)（SHA256: db48af60c7ce76012ef65c5466cf25cb086a89cb01ac6f37be05bf0cbb0b00ab）
+- [易用性構面](https://github.com/nics-tw/resilience-material/releases/download/2025/2_Usability.pdf)（SHA256: 52230d5eb66843ada28cb67a183d80a78eed7b4280080fc73878fbab4fb0c5b1）
+- [各面向工具](https://github.com/nics-tw/resilience-material/releases/download/2025/3_Digital_Resilience-Related_Tools.pdf)（SHA256: 319aa25a3c9ee91c03b6c8692e9a034f20e2439ebe4d6f379166b7128b89db79）
+- [高可用性構面](https://github.com/nics-tw/resilience-material/releases/download/2025/4_High-Availability.pdf)（SHA256: d1e3601897a9e63ff19ff0dfad8b4f93493aafd88283aa8c34cd5d7c62c88eed）
+- [可維護性構面](https://github.com/nics-tw/resilience-material/releases/download/2025/5_Maintainability.pdf)（SHA256: 21db868fd033ec6ec7a964c754ef9e9a24d741fa5ccba333b37565498df5edb5）
+- [實地輔導可維護性案例分享](https://github.com/nics-tw/resilience-material/releases/download/2025/6_Maintainability_Best_Practices.pdf)（SHA256: 4c116e03eb780fb763c689f28ae5fea87256da8467d4293f099166ef5bb07636）
+- [實地輔導高可用性案例分享](https://github.com/nics-tw/resilience-material/releases/download/2025/7_High-Availability_Case_Studies.pdf)（SHA256: 4d768bc86ac37ba133bc4103ab72a132e928bd8ffdfb547a353d2dac47fa4bcd）
+
 ### [2024 年](https://github.com/nics-tw/resilience-material/releases/tag/2024)
 
 - [政府資訊系統數位韌性](https://github.com/nics-tw/resilience-material/releases/download/2024/1_Digital_Resilience.pdf)（SHA256: 896E8B6794310335421A3BEF2E404836FD2D03AC6C9E295F86483395653B5447）

--- a/docs/training.md
+++ b/docs/training.md
@@ -10,6 +10,10 @@ import TrainingList from '@site/src/components/TrainingList';
 
 本專區提供數位韌性教材說明數位韌性原則與實務，將陸續增加數位韌性共享資源包括 SBOM 工具操作說明、設計系統元件使用情境與資訊系統專案中文化，讓數位共享資源作為政府資訊系統引用之參考資料，有助精進政府機關資訊系統服務品質。
 
+## [2025 年](https://github.com/nics-tw/resilience-material/releases/tag/2025)
+
+<TrainingList year={2025} />
+
 ## [2024 年](https://github.com/nics-tw/resilience-material/releases/tag/2024)
 
 <TrainingList year={2024} />

--- a/src/components/TrainingList/data.json
+++ b/src/components/TrainingList/data.json
@@ -1,4 +1,48 @@
 {
+  "2025": [
+    {
+      "name": "政府資訊系統數位韌性",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/1_Digital_Resilience.pdf",
+      "sha256": "db48af60c7ce76012ef65c5466cf25cb086a89cb01ac6f37be05bf0cbb0b00ab",
+      "youtube": "1nCSBpkYEDA"
+    },
+    {
+      "name": "易用性構面",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/2_Usability.pdf",
+      "sha256": "52230d5eb66843ada28cb67a183d80a78eed7b4280080fc73878fbab4fb0c5b1",
+      "youtube": "Q-tbnHim8wc"
+    },
+    {
+      "name": "各面向工具",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/3_Digital_Resilience-Related_Tools.pdf",
+      "sha256": "319aa25a3c9ee91c03b6c8692e9a034f20e2439ebe4d6f379166b7128b89db79",
+      "youtube": "JvER5--KzwQ"
+    },
+    {
+      "name": "高可用性構面",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/4_High-Availability.pdf",
+      "sha256": "d1e3601897a9e63ff19ff0dfad8b4f93493aafd88283aa8c34cd5d7c62c88eed",
+      "youtube": "JvJ1yjykBSc"
+    },
+    {
+      "name": "可維護性構面",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/5_Maintainability.pdf",
+      "sha256": "21db868fd033ec6ec7a964c754ef9e9a24d741fa5ccba333b37565498df5edb5",
+      "youtube": "QHFONLeuDfU"
+    },
+    {
+      "name": "實地輔導可維護性案例分享",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/6_Maintainability_Case_Studies.pdf",
+      "sha256": "4c116e03eb780fb763c689f28ae5fea87256da8467d4293f099166ef5bb07636",
+      "youtube": "OAFnvBpL4aQ"
+    },
+    {
+      "name": "實地輔導高可用性案例分享",
+      "link": "https://github.com/nics-tw/resilience-material/releases/download/2025/7_High-Availability_Case_Studies.pdf",
+      "sha256": "4d768bc86ac37ba133bc4103ab72a132e928bd8ffdfb547a353d2dac47fa4bcd",
+      "youtube": "NAOb8hSeiak"
+    }
+  ],
   "2024": [
     {
       "name": "政府資訊系統數位韌性",


### PR DESCRIPTION
[數位韌性領航員培訓課程教材](https://material.nics.nat.gov.tw/material/training)頁面新增 2025 年教材，並同步更新 [README.md](https://github.com/nics-tw/resilience-material/blob/main/README.md)。